### PR TITLE
feat: finder, several bugfixes for zoom

### DIFF
--- a/src/components/canvas/canvas.js
+++ b/src/components/canvas/canvas.js
@@ -49,7 +49,7 @@ const Canvas = () => {
 
         <div className="item h-full w-full" ref={contextRef} id="canvas">
           <SubMenu />
-          <ZoomableSVG width={width} height={height}>
+          <ZoomableSVG width={width} height={height} treeName={name}>
             {name && (
               <Dendrogram
                 data={tree}

--- a/src/components/canvas/hooks/useZoom.js
+++ b/src/components/canvas/hooks/useZoom.js
@@ -7,10 +7,10 @@ const useZoom = () => {
     const tree = useSelector(getTree);
     const { width, height } = tree
     const handleAddZoomClick = useCallback(() => {
-        dispatch(set({...tree, width: (width * 2), height: (height * 2)}))
+        dispatch(set({...tree, width: (width * 2), height: (height * 2), zoom: null}))
     }, [dispatch, tree, width, height])
     const handleSubstractZoomClick = useCallback(() => {
-        dispatch(set({...tree, width: (width / 2), height: (height / 2)}))
+        dispatch(set({...tree, width: (width / 2), height: (height / 2), zoom: null}))
     }, [dispatch, tree, width, height]);
     return {
         handleAddZoomClick,

--- a/src/components/canvas/hooks/zoomable.js
+++ b/src/components/canvas/hooks/zoomable.js
@@ -1,14 +1,29 @@
-import { zoom, select } from 'd3';
+import { zoom, select, zoomIdentity } from 'd3';
 import { useRef } from 'react';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
 import useSubMenu from '../../submenu/useSubmenu';
+import { getFindNodeName, clearFindNodeName } from '../../store/dashboard/slice';
+import { getZoom, setZoom } from '../../store/tree/slice';
 
-export default function ZoomableSVG({ children, width, height }) {
+export default function ZoomableSVG({ children, width, height, treeName }) {
   const svgRef = useRef();
+  const zoomRef = useRef();
+  const saveTimerRef = useRef();
   const [k, setK] = useState(1);
   const [x, setX] = useState(width);
   const [y, setY] = useState(height);
   const { handleClose } = useSubMenu();
+  const findNodeName = useSelector(getFindNodeName);
+  const savedZoom = useSelector(getZoom);
+  const dispatch = useDispatch();
+
+  const saveZoom = useCallback((transform) => {
+    clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      dispatch(setZoom({ x: transform.x, y: transform.y, k: transform.k }));
+    }, 500);
+  }, [dispatch]);
 
   useEffect(() => {
     const svg = select(svgRef.current);
@@ -17,12 +32,60 @@ export default function ZoomableSVG({ children, width, height }) {
       setX(x);
       setY(y);
       setK(k);
+      saveZoom(event.transform);
     });
+    zoomRef.current = zoomed;
     svg.call(zoomed);
     return () => {
       svg.on('.zoom', null);
+      clearTimeout(saveTimerRef.current);
     };
-  }, []);
+  }, [saveZoom]);
+
+  useEffect(() => {
+    if (!svgRef.current || !zoomRef.current) return;
+    const svgEl = svgRef.current;
+
+    if (savedZoom) {
+      const restoredTransform = zoomIdentity.translate(savedZoom.x, savedZoom.y).scale(savedZoom.k);
+      select(svgEl).call(zoomRef.current.transform, restoredTransform);
+    } else {
+      const svgRect = svgEl.getBoundingClientRect();
+      const centerX = (svgRect.width - width) / 2;
+      const centerY = (svgRect.height - height) / 2;
+      const newTransform = zoomIdentity.translate(centerX, centerY);
+      select(svgEl).call(zoomRef.current.transform, newTransform);
+    }
+  }, [width, height, treeName]);
+
+  useEffect(() => {
+    if (!findNodeName || !svgRef.current) return;
+    const svg = svgRef.current;
+    const labels = svg.querySelectorAll('.label');
+    let target = null;
+    for (const label of labels) {
+      if (label.textContent === findNodeName) {
+        target = label;
+        break;
+      }
+    }
+    if (!target || !zoomRef.current) {
+      dispatch(clearFindNodeName());
+      return;
+    }
+    const svgRect = svg.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();
+    const centerX = svgRect.width / 2;
+    const centerY = svgRect.height / 2;
+    const targetCenterX = targetRect.left - svgRect.left + targetRect.width / 2;
+    const targetCenterY = targetRect.top - svgRect.top + targetRect.height / 2;
+    const newX = x + (centerX - targetCenterX);
+    const newY = y + (centerY - targetCenterY);
+    const newTransform = zoomIdentity.translate(newX, newY).scale(k);
+    select(svg).transition().duration(500).call(zoomRef.current.transform, newTransform);
+    dispatch(clearFindNodeName());
+  }, [findNodeName, dispatch, x, y, k]);
+
   return (
     <svg ref={svgRef} width={'100%'} height={'100%'} onClick={handleClose}>
       <g transform={`translate(${x},${y})scale(${k})`}>{children}</g>

--- a/src/components/dashboard/dashboard.js
+++ b/src/components/dashboard/dashboard.js
@@ -10,6 +10,7 @@ import { getTree } from '../store/tree/slice';
 import { getFile } from '../store/file/slice';
 import { getError } from '../store/error/slice';
 import Footer from '../footer/footer';
+import NodeFinder from '../nodefinder/nodefinder';
 
 import {
   useUpload,
@@ -141,7 +142,12 @@ export default function Dashboard() {
               </Button>
             </form>
           </div>
-          <div className="divider mt-2 mb-2"></div>
+          <div className="flex flex-col mt-6 mb-6">
+            <Card.Title className="text-white items-end text-md">
+              Buscar Nodo
+            </Card.Title>
+            <NodeFinder disabled={!fileName} />
+          </div>
           {/**
            * Visualizacion de arbol
            */}

--- a/src/components/dashboard/hooks/useNodeFinder.js
+++ b/src/components/dashboard/hooks/useNodeFinder.js
@@ -1,0 +1,45 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { getTree } from '../../store/tree/slice';
+import { setFindNodeName } from '../../store/dashboard/slice';
+
+function collectNames(node, set) {
+  if (node.name) set.add(node.name);
+  if (node.children) {
+    node.children.forEach((child) => collectNames(child, set));
+  }
+}
+
+export default function useNodeFinder() {
+  const dispatch = useDispatch();
+  const { tree, name: treeName } = useSelector(getTree);
+  const [query, setQuery] = useState('');
+
+  const nodeNames = useMemo(() => {
+    if (!treeName) return [];
+    const names = new Set();
+    collectNames(tree, names);
+    return Array.from(names).sort();
+  }, [tree, treeName]);
+
+  const handleSearch = useCallback(() => {
+    const trimmed = query.trim();
+    if (!trimmed || !nodeNames.includes(trimmed)) return;
+    dispatch(setFindNodeName(trimmed));
+  }, [query, nodeNames, dispatch]);
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSearch();
+    }
+  }, [handleSearch]);
+
+  return {
+    query,
+    setQuery,
+    nodeNames,
+    handleSearch,
+    handleKeyDown,
+  };
+}

--- a/src/components/dashboard/hooks/useUpload.js
+++ b/src/components/dashboard/hooks/useUpload.js
@@ -82,6 +82,7 @@ const useUpload = () => {
           width,
           height,
           tree: treeDoc,
+          zoom,
         } = JSON.parse(content);
         dispatch(
           set({
@@ -94,6 +95,7 @@ const useUpload = () => {
             width: width,
             height: height,
             tree: treeDoc,
+            zoom: zoom,
           })
         );
         dispatch(clearContent());

--- a/src/components/nodefinder/nodefinder.js
+++ b/src/components/nodefinder/nodefinder.js
@@ -1,0 +1,37 @@
+import useNodeFinder from '../dashboard/hooks/useNodeFinder';
+
+const NodeFinder = ({ disabled }) => {
+  const { query, setQuery, nodeNames, handleSearch, handleKeyDown } =
+    useNodeFinder();
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex gap-2 mt-2">
+        <input
+          type="text"
+          list="node-names-list"
+          className="input w-full h-8 min-h-8 rounded-md bg-[#FAEECC] text-sm"
+          placeholder="Buscar nodo..."
+          disabled={disabled}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <button
+          className="btn btn-secondary h-8 min-h-8 text-white text-sm"
+          disabled={disabled || !query.trim()}
+          onClick={handleSearch}
+        >
+          Buscar
+        </button>
+      </div>
+      <datalist id="node-names-list">
+        {nodeNames.map((name) => (
+          <option key={name} value={name} />
+        ))}
+      </datalist>
+    </div>
+  );
+};
+
+export default NodeFinder;

--- a/src/components/store/dashboard/slice.js
+++ b/src/components/store/dashboard/slice.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
     isHamburgerMenuActive: false,
+    findNodeName: null,
 };
 
 const dashboardSlice = createSlice({
@@ -14,10 +15,17 @@ const dashboardSlice = createSlice({
         setHamburgerMenuActive: (state, action) => {
             state.isHamburgerMenuActive = action.payload;
         },
+        setFindNodeName: (state, action) => {
+            state.findNodeName = action.payload;
+        },
+        clearFindNodeName: (state) => {
+            state.findNodeName = null;
+        },
     },
 });
 
 export const getHamburgerMenuActive = (state) => state.dashboard.isHamburgerMenuActive;
-export const { toggleHamburgerMenu, setHamburgerMenuActive } = dashboardSlice.actions;
+export const getFindNodeName = (state) => state.dashboard.findNodeName;
+export const { toggleHamburgerMenu, setHamburgerMenuActive, setFindNodeName, clearFindNodeName } = dashboardSlice.actions;
 
 export default dashboardSlice.reducer;

--- a/src/components/store/tree/slice.js
+++ b/src/components/store/tree/slice.js
@@ -22,6 +22,7 @@ const treeSlice = createSlice({
       state.width = action.payload.width;
       state.height = action.payload.height;
       state.globalStyles = action.payload.globalStyles;
+      state.zoom = action.payload.zoom ?? null;
     },
     setStyle: (state, action) => {
       state.globalStyles = action.payload.globalStyles;
@@ -38,11 +39,16 @@ const treeSlice = createSlice({
       const { id, pathStyle } = action.payload;
       modifyEspecificPathStyle(state.tree, pathStyle, id);
     },
+    setZoom: (state, action) => {
+      state.zoom = action.payload;
+    },
   },
 });
 
 export const getTree = (state) => state.tree;
 
-export const { set, setStyle, setNodeStyleById, setLabelStyleById, setPathStyleById, RESET } = treeSlice.actions;
+export const { set, setStyle, setNodeStyleById, setLabelStyleById, setPathStyleById, setZoom, RESET } = treeSlice.actions;
+
+export const getZoom = (state) => state.tree.zoom;
 
 export default treeSlice.reducer;

--- a/src/lib/TreeData.js
+++ b/src/lib/TreeData.js
@@ -231,6 +231,7 @@ export const createTreeState = ({
   height = 600,
   globalStyles = createBaseGlobalStyles({}),
   tree = createBaseTree(),
+  zoom = null,
 }) => {
   return {
     name,
@@ -241,5 +242,6 @@ export const createTreeState = ({
     height,
     globalStyles,
     tree,
+    zoom,
   };
 };


### PR DESCRIPTION
## Revisores

## Cambios

### 1. Buscador de nodos por etiqueta (Node Finder)

Se agrega un nuevo componente que permite buscar nodos del dendrograma por nombre y navegar automáticamente hacia ellos en el canvas.

**Archivos nuevos:**
- `src/components/nodefinder/nodefinder.js` — Componente de búsqueda con `<input>` + `<datalist>` para autocompletado y botón "Buscar"
- `src/components/dashboard/hooks/useNodeFinder.js` — Hook que recolecta nombres de nodos con `collectNames()`, mantiene el `query` y despacha `setFindNodeName`

**Archivos modificados:**
- `src/components/dashboard/dashboard.js` — Se agrega sección "Buscar Nodo" con el componente `NodeFinder` entre el formulario de carga y la sección de visualización
- `src/components/store/dashboard/slice.js` — Nuevo estado `findNodeName` con acciones `setFindNodeName` y `clearFindNodeName`, y selector `getFindNodeName`

### 2. Auto-centrado del dendrograma al cargar

El dendrograma ahora se centra automáticamente en el viewport al ser cargado, y también al recargar el mismo archivo.

**Archivos modificados:**
- `src/components/canvas/hooks/zoomable.js` — Se agrega `useEffect` que calcula el centrado usando `getBoundingClientRect()` y aplica `zoomIdentity.translate()`. Se guarda referencia al zoom en `zoomRef` para uso programático
- `src/components/canvas/canvas.js` — Se pasa `treeName={name}` como prop a `ZoomableSVG` para que el efecto de centrado se re-ejecute al cambiar de árbol (incluido recargar el mismo archivo)

### 3. Navegación al nodo buscado (pan-to-node)

Al buscar un nodo, el canvas se desplaza suavemente hasta centrar la etiqueta encontrada.

**Archivos modificados:**
- `src/components/canvas/hooks/zoomable.js` — Se agrega `useEffect` que escucha `findNodeName`, busca el `<text class="label">` correspondiente en el DOM, calcula el offset y aplica una transición D3 de 500ms con `zoomIdentity.translate().scale()` para centrar el nodo

### 4. Persistencia de zoom en el estado del árbol

El estado de zoom (posición x, y y escala k) se guarda en el objeto del árbol en Redux, permitiendo:
- Restaurar la vista al recargar un JSON exportado que incluye zoom
- Mantener la posición al navegar entre acciones

**Archivos modificados:**
- `src/lib/TreeData.js` — Nuevo campo `zoom: null` en `createTreeState`
- `src/components/store/tree/slice.js` — Nuevo reducer `setZoom`, selector `getZoom`, y `set` ahora persiste `zoom` del payload (con fallback `?? null` para archivos sin zoom)
- `src/components/canvas/hooks/zoomable.js` — Al hacer pan/zoom se despacha `setZoom` con debounce de 500ms. Al cargar un árbol, si tiene zoom guardado lo restaura; si no, centra como antes
- `src/components/canvas/hooks/useZoom.js` — Los botones +/- limpian `zoom: null` al cambiar dimensiones para que re-centre correctamente
- `src/components/dashboard/hooks/useUpload.js` — Se extrae `zoom` del JSON al cargar y se incluye en el dispatch de `set`

### Resumen de archivos

| Archivo | Cambio |
|---|---|
| `src/components/nodefinder/nodefinder.js` | **Nuevo** — Componente buscador de nodos |
| `src/components/dashboard/hooks/useNodeFinder.js` | **Nuevo** — Hook del buscador |
| `src/components/canvas/hooks/zoomable.js` | Centrado automático, pan-to-node, persistencia de zoom |
| `src/components/canvas/canvas.js` | Pasa `treeName` a `ZoomableSVG` |
| `src/components/canvas/hooks/useZoom.js` | Limpia zoom al usar botones +/- |
| `src/components/dashboard/dashboard.js` | Sección "Buscar Nodo" |
| `src/components/dashboard/hooks/useUpload.js` | Extrae y pasa `zoom` del JSON |
| `src/components/store/dashboard/slice.js` | Estado `findNodeName` |
| `src/components/store/tree/slice.js` | Reducer `setZoom`, selector `getZoom` |
| `src/lib/TreeData.js` | Campo `zoom` en `createTreeState` |

**10 archivos cambiados** — 179 adiciones, 10 eliminaciones

## Tarea o asunto asociado

Feature: Buscador de nodos, auto-centrado de dendrograma, y persistencia de zoom

## Evidencia del cambio