### PR TITLE
feat: rediseño amigable del menú de contexto del lienzo

### DIFF
--- a/src/components/canvas/canvas.js
+++ b/src/components/canvas/canvas.js
@@ -52,7 +52,7 @@ const Canvas = () => {
           <ZoomSubsIcon />
         </button>
 
-        <div className="item h-full w-full" ref={contextRef} id="canvas">
+        <div className="item relative h-full w-full" ref={contextRef} id="canvas">
           <SubMenu />
           {name ? (
             <ZoomableSVG width={width} height={height} treeName={name}>

--- a/src/components/canvas/canvas.js
+++ b/src/components/canvas/canvas.js
@@ -26,8 +26,8 @@ const Canvas = () => {
     <Card
       className={
         isOpen
-          ? `bg-parchment m-4 rounded-md border-none w-full`
-          : ` bg-parchment m-4 rounded-md border-none w-5/6`
+          ? `bg-parchment m-2 lg:m-4 rounded-md border-none w-full`
+          : `bg-parchment m-2 lg:m-4 rounded-md border-none w-full lg:w-5/6`
       }
     >
       <div className="flex justify-center h-full">

--- a/src/components/common/colorField.js
+++ b/src/components/common/colorField.js
@@ -129,6 +129,7 @@ export default function ColorField({
             ref={popoverRef}
             role="dialog"
             aria-label={label ?? 'Selector de color'}
+            data-color-popover=""
             style={{ position: 'fixed', top: position.top, left: position.left, zIndex: 1000 }}
           >
             <Sketch

--- a/src/components/dashboard/dashboard.js
+++ b/src/components/dashboard/dashboard.js
@@ -21,9 +21,27 @@ import {
   useCleanDashboard,
   useDendrogramForm,
   useBurgerMenu,
+  useMediaQuery,
 } from './hooks';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 const accepts = ['.nwk', '.json'];
+
+// Por debajo de `lg` (Tailwind 1024px) el panel se comporta como drawer.
+const BELOW_LG = '(max-width: 1023px)';
+
+// Logo de Phily reutilizado en el rail, el encabezado del panel y el botón
+// flotante. Se hoistea fuera del componente para no recrearlo en cada render
+// (rendering-hoist-jsx).
+const PhilyLogo = ({ priority = false }) => (
+  <Image
+    src="/treeIcon.svg"
+    width={86}
+    height={82}
+    className="invert"
+    alt="Phily"
+    priority={priority}
+  />
+);
 
 // Disclosure progresivo (A3, D1, D2): cada sección del panel es un <details>
 // accesible cuyo resumen lleva el glifo de rama (firma §6). Se atenúa y colapsa
@@ -63,7 +81,7 @@ export default function Dashboard() {
     labelSize,
     labelColor,
   } = useStyle();
-  const { isOpen, handleOpen } = useBurgerMenu();
+  const { isOpen, handleOpen, setOpen } = useBurgerMenu();
   const { handleCleanClick } = useCleanDashboard();
   const {
     handleCurveChange,
@@ -80,6 +98,45 @@ export default function Dashboard() {
     [handleCurveChange]
   );
 
+  // `isOpen` (redux) representa "panel colapsado". En escritorio alterna entre
+  // panel completo y rail; por debajo de `lg` decide si el drawer está abierto.
+  const isSmallScreen = useMediaQuery(BELOW_LG);
+  const collapsed = isOpen;
+  const drawerOpen = isSmallScreen && !collapsed;
+
+  const panelRef = useRef(null);
+  const toggleRef = useRef(null);
+
+  // Cierra el drawer y devuelve el foco al botón flotante. En ref para que los
+  // listeners globales no se re-suscriban en cada render (advanced-event-handler-refs).
+  const closeRef = useRef(null);
+  closeRef.current = () => {
+    setOpen(true);
+    toggleRef.current?.focus();
+  };
+
+  // Al entrar a viewport pequeño, colapsa para mostrar primero el árbol.
+  useEffect(() => {
+    if (isSmallScreen) setOpen(true);
+  }, [isSmallScreen, setOpen]);
+
+  // Con el drawer abierto: foco dentro del panel, Escape cierra y se bloquea el
+  // scroll del fondo. Todo se limpia al cerrar.
+  useEffect(() => {
+    if (!drawerOpen) return undefined;
+    panelRef.current?.focus();
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') closeRef.current?.();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [drawerOpen]);
+
   // Las secciones se abren al cargar un archivo y se colapsan al limpiarlo; el
   // usuario puede plegarlas/desplegarlas manualmente (onToggle sincroniza).
   const [openSections, setOpenSections] = useState({
@@ -95,35 +152,73 @@ export default function Dashboard() {
     setOpenSections((prev) => ({ ...prev, [key]: value }));
   }, []);
 
-  if (isOpen) {
-    return (
-      <>
-        <Card className="bg-primary w-20 p-4 rounded-none border-none overflow-y-auto scrollbar scrollbar-none ml-1/5">
-          <button
-            onClick={handleOpen}
-            id="deleteFile"
-            type="button"
-            aria-label="Expandir panel"
-          >
-            <Image
-              src="/treeIcon.svg"
-              width={86}
-              height={82}
-              className="invert"
-              alt="logo"
-              priority={true}
-            />
-          </button>
-        </Card>
-      </>
-    );
-  }
   return (
     <>
-      <Card
-        id="dashboard"
-        className="bg-primary w-auto p-4 rounded-none border-none overflow-y-auto scrollbar scrollbar-none"
+      {/* Botón flotante (solo < lg): abre el drawer. Se oculta mientras está
+          abierto porque el propio panel ofrece el cierre. */}
+      <button
+        ref={toggleRef}
+        onClick={handleOpen}
+        type="button"
+        aria-label="Abrir panel"
+        aria-expanded={drawerOpen}
+        aria-controls="dashboard-panel"
+        className={`lg:hidden fixed left-3 top-3 z-50 h-12 w-12 items-center justify-center rounded-full bg-primary shadow-lg ${
+          drawerOpen ? 'hidden' : 'flex'
+        }`}
+      >
+        <Image
+          src="/treeIcon.svg"
+          width={32}
+          height={30}
+          className="invert"
+          alt="Phily"
+          priority
+        />
+      </button>
+
+      {/* Backdrop del drawer (solo < lg cuando está abierto). */}
+      {drawerOpen ? (
+        <div
+          className="lg:hidden fixed inset-0 z-40 bg-ink/50"
+          onClick={() => closeRef.current?.()}
+          aria-hidden="true"
+        />
+      ) : null}
+
+      {/* Rail colapsado (solo escritorio): muestra el logo para re-expandir. */}
+      {collapsed ? (
+        <Card className="hidden lg:flex bg-primary w-20 p-4 rounded-none border-none overflow-y-auto scrollbar scrollbar-none">
+          <button
+            onClick={handleOpen}
+            id="expandPanel"
+            type="button"
+            aria-label="Expandir panel"
+            aria-expanded={false}
+            aria-controls="dashboard-panel"
+          >
+            <PhilyLogo priority />
+          </button>
+        </Card>
+      ) : null}
+
+      {/* Panel: en escritorio es columna en flujo; por debajo de `lg` es un
+          drawer deslizante superpuesto. Se mantiene montado para animar y
+          gestionar el foco. */}
+      <aside
+        id="dashboard-panel"
+        ref={panelRef}
+        tabIndex={-1}
+        role={isSmallScreen ? 'dialog' : undefined}
+        aria-modal={isSmallScreen ? drawerOpen : undefined}
+        aria-label="Panel de control"
         onContextMenu={(e) => e.preventDefault()}
+        className={`bg-primary p-4 overflow-y-auto scrollbar scrollbar-none focus:outline-none
+          fixed inset-y-0 left-0 z-50 w-[min(86vw,360px)] max-w-full
+          transition-transform duration-200 ease-out motion-reduce:transition-none
+          ${drawerOpen ? 'translate-x-0' : '-translate-x-full'}
+          lg:static lg:z-auto lg:w-auto lg:max-w-none lg:translate-x-0 lg:transition-none
+          ${collapsed ? 'lg:hidden' : 'lg:block'}`}
       >
         {message && <Error message={message} open={open} />}
         <div className="grid grid-cols-1">
@@ -132,14 +227,10 @@ export default function Dashboard() {
               onClick={handleOpen}
               type="button"
               aria-label="Contraer panel"
+              aria-expanded={!collapsed}
+              aria-controls="dashboard-panel"
             >
-              <Image
-                src="/treeIcon.svg"
-                width={86}
-                height={82}
-                className="invert"
-                alt="logo"
-              />
+              <PhilyLogo />
             </button>
             <Card.Title className="text-white ml-2 items-end text-4xl align-middle font-display">
               Phily
@@ -204,9 +295,9 @@ export default function Dashboard() {
               <span className="label-text text-white text-lg mt-2 text-center">
                 Lateral
               </span>
-              <div className="flex justify-evenly md:flex-row sm:flex-col mt-2">
+              <div className="flex flex-col gap-2 mt-2 lg:flex-row lg:justify-evenly">
                 <button
-                  className={`btn h-8 min-h-8 min-w-24 border-none rounded-md ${deferredCurveType === 'step' ? 'bg-signal text-white' : 'bg-lichen text-ink'}`}
+                  className={`btn h-8 min-h-8 w-full lg:w-auto lg:min-w-24 border-none rounded-md ${deferredCurveType === 'step' ? 'bg-signal text-white' : 'bg-lichen text-ink'}`}
                   value={'step'}
                   disabled={!fileName}
                   onClick={handleStepChange}
@@ -214,7 +305,7 @@ export default function Dashboard() {
                   Escalón
                 </button>
                 <button
-                  className={`btn h-8 min-h-8 min-w-24 border-none rounded-md ${deferredCurveType === 'curve' ? 'bg-signal text-white' : 'bg-lichen text-ink'}`}
+                  className={`btn h-8 min-h-8 w-full lg:w-auto lg:min-w-24 border-none rounded-md ${deferredCurveType === 'curve' ? 'bg-signal text-white' : 'bg-lichen text-ink'}`}
                   value={'curve'}
                   disabled={!fileName}
                   onClick={handleStepChange}
@@ -222,7 +313,7 @@ export default function Dashboard() {
                   Suave
                 </button>
                 <button
-                  className={`btn h-8 min-h-8 min-w-24 border-none rounded-md ${deferredCurveType === 'slanted' ? 'bg-signal text-white' : 'bg-lichen text-ink'}`}
+                  className={`btn h-8 min-h-8 w-full lg:w-auto lg:min-w-24 border-none rounded-md ${deferredCurveType === 'slanted' ? 'bg-signal text-white' : 'bg-lichen text-ink'}`}
                   value={'slanted'}
                   disabled={!fileName}
                   onClick={handleStepChange}
@@ -233,9 +324,9 @@ export default function Dashboard() {
               <span className="label-text text-white text-lg text-left mt-2">
                 Circular
               </span>
-              <div className="flex justify-evenly md:flex-row sm:flex-col mt-2">
+              <div className="flex flex-col gap-2 mt-2 lg:flex-row lg:justify-evenly">
                 <button
-                  className={`btn h-8 min-h-8 min-w-36 border-none rounded-md ${deferredCurveType === 'circular' ? 'bg-signal text-white' : 'bg-lichen text-ink'}`}
+                  className={`btn h-8 min-h-8 w-full lg:w-auto lg:min-w-36 border-none rounded-md ${deferredCurveType === 'circular' ? 'bg-signal text-white' : 'bg-lichen text-ink'}`}
                   value={'circular'}
                   disabled={!fileName}
                   onClick={handleStepChange}
@@ -243,7 +334,7 @@ export default function Dashboard() {
                   Circular
                 </button>
                 <button
-                  className={`btn h-8 min-h-8 min-w-36 border-none rounded-md ${curveType === 'circular-step' ? 'bg-signal text-white' : 'bg-lichen text-ink'}`}
+                  className={`btn h-8 min-h-8 w-full lg:w-auto lg:min-w-36 border-none rounded-md ${curveType === 'circular-step' ? 'bg-signal text-white' : 'bg-lichen text-ink'}`}
                   value={'circular-step'}
                   disabled={!fileName}
                   onClick={handleStepChange}
@@ -294,26 +385,27 @@ export default function Dashboard() {
               <Card.Title className="text-white items-end text-sm mt-2">
                 Enlaces
               </Card.Title>
-              <div className="flex justify-evenly md:flex-row sm:flex-col ">
-                <div className="md:flex-row sm:flex-col relative">
+              <div className="flex flex-col gap-2 lg:flex-row lg:justify-evenly">
+                <div className="w-full lg:w-auto">
                   <label className="label text-white text-sm" htmlFor="path-width">Ancho</label>
 
                   <input
                     id="path-width"
                     type="number"
-                    className="input w-40 h-6 min-h-6 rounded-md mr-2 bg-parchment text-ink font-mono"
+                    className="input w-full lg:w-40 h-6 min-h-6 rounded-md bg-parchment text-ink font-mono"
                     placeholder="48px"
                     disabled={!fileName}
                     value={pathWidth}
                     onChange={pathWidthChange}
                   />
                 </div>
-                <div className="md:flex-row sm:flex-col">
+                <div className="w-full lg:w-auto">
                   <label className="label text-white text-sm" htmlFor="path-color">Color</label>
                   <ColorField
                     id="path-color"
                     label="Color de enlace"
-                    swatchClassName="w-40 h-6 min-h-6 rounded-md"
+                    className="block w-full lg:w-40"
+                    swatchClassName="w-full lg:w-40 h-6 min-h-6 rounded-md"
                     disabled={!fileName}
                     value={pathColor}
                     onChange={pathColorChange}
@@ -323,13 +415,13 @@ export default function Dashboard() {
               <Card.Title className="text-white items-end text-sm mt-2">
                 Nodos
               </Card.Title>
-              <div className="flex justify-evenly md:flex-row sm:flex-col ">
-                <div className="md:flex-row sm:flex-col">
+              <div className="flex flex-col gap-2 lg:flex-row lg:justify-evenly">
+                <div className="w-full lg:w-auto">
                   <label className="label text-white text-sm" htmlFor="node-radius">Radio</label>
                   <input
                     id="node-radius"
                     type="number"
-                    className="input w-40 h-6 min-h-6 rounded-md mr-2 bg-parchment text-ink font-mono"
+                    className="input w-full lg:w-40 h-6 min-h-6 rounded-md bg-parchment text-ink font-mono"
                     placeholder="10px"
                     min={0}
                     disabled={!fileName}
@@ -337,12 +429,13 @@ export default function Dashboard() {
                     onChange={nodeRadiusChange}
                   />
                 </div>
-                <div className="md:flex-row sm:flex-col">
+                <div className="w-full lg:w-auto">
                   <label className="label text-white text-sm" htmlFor="node-color">Color</label>
                   <ColorField
                     id="node-color"
                     label="Color de nodo"
-                    swatchClassName="w-40 h-6 min-h-6 rounded-md"
+                    className="block w-full lg:w-40"
+                    swatchClassName="w-full lg:w-40 h-6 min-h-6 rounded-md"
                     disabled={!fileName}
                     value={nodeColor}
                     onChange={nodeColorChange}
@@ -352,13 +445,13 @@ export default function Dashboard() {
               <Card.Title className="text-white items-end text-sm mt-2">
                 Etiquetas
               </Card.Title>
-              <div className="flex justify-evenly md:flex-row sm:flex-col ">
-                <div className="md:flex-row sm:flex-col">
+              <div className="flex flex-col gap-2 lg:flex-row lg:justify-evenly">
+                <div className="w-full lg:w-auto">
                   <label className="label text-white text-sm" htmlFor="label-size">Tamaño</label>
                   <input
                     id="label-size"
                     type="number"
-                    className="input w-40 h-6 min-h-6 rounded-md mr-2 bg-parchment text-ink font-mono"
+                    className="input w-full lg:w-40 h-6 min-h-6 rounded-md bg-parchment text-ink font-mono"
                     placeholder="48px"
                     min={0}
                     disabled={!fileName}
@@ -366,12 +459,13 @@ export default function Dashboard() {
                     onChange={labelSizeChange}
                   />
                 </div>
-                <div className="md:flex-row sm:flex-col">
+                <div className="w-full lg:w-auto">
                   <label className="label text-white text-sm" htmlFor="label-color">Color</label>
                   <ColorField
                     id="label-color"
                     label="Color de etiqueta"
-                    swatchClassName="w-40 h-6 min-h-6 rounded-md"
+                    className="block w-full lg:w-40"
+                    swatchClassName="w-full lg:w-40 h-6 min-h-6 rounded-md"
                     disabled={!fileName}
                     value={labelColor}
                     onChange={labelColorChange}
@@ -388,9 +482,9 @@ export default function Dashboard() {
                 onToggle={(v) => toggleSection('export', v)}
                 disabled={!fileName}
               >
-              <div className="flex justify-evenly md:flex-row sm:flex-col mt-2">
+              <div className="flex flex-col gap-2 mt-2 lg:flex-row lg:justify-evenly">
                 <select
-                  className="select select-bordered select-primary w-48 h-8 min-h-8 rounded-md bg-parchment text-ink"
+                  className="select select-bordered select-primary w-full lg:w-48 h-8 min-h-8 rounded-md bg-parchment text-ink"
                   aria-label="Formato de exportación"
                   defaultValue={download}
                   onChange={handleChangeSelectDownload}
@@ -403,7 +497,7 @@ export default function Dashboard() {
                   <option>json</option>
                 </select>
                 <button
-                  className="btn btn-secondary text-white min-h-8 h-8 w-40 mx-2"
+                  className="btn btn-secondary text-white min-h-8 h-8 w-full lg:w-40"
                   onClick={handleDownload}
                   disabled={!fileName}
                 >
@@ -416,7 +510,7 @@ export default function Dashboard() {
           </div>
         </div>
         <Footer />
-      </Card>
+      </aside>
     </>
   );
 }

--- a/src/components/dashboard/hooks/index.js
+++ b/src/components/dashboard/hooks/index.js
@@ -4,11 +4,13 @@ import useStyle from './useStyle';
 import useUpload from './useUpload';
 import useDendrogramForm from './useDendrogramForm';
 import useBurgerMenu from './useBurgerMenu';
+import useMediaQuery from './useMediaQuery';
 export {
   useCleanDashboard,
   useDownload,
   useStyle,
   useUpload,
   useDendrogramForm,
-  useBurgerMenu
+  useBurgerMenu,
+  useMediaQuery,
 };

--- a/src/components/dashboard/hooks/useBurgerMenu.js
+++ b/src/components/dashboard/hooks/useBurgerMenu.js
@@ -1,9 +1,18 @@
+import { useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { toggleHamburgerMenu, getHamburgerMenuActive } from '@/components/store/dashboard/slice';
+import {
+  toggleHamburgerMenu,
+  setHamburgerMenuActive,
+  getHamburgerMenuActive,
+} from '@/components/store/dashboard/slice';
 
-export default function useBurgerMenu(){
-    const isOpen = useSelector(getHamburgerMenuActive);
-    const dispatch = useDispatch();
-    const handleOpen = () => dispatch(toggleHamburgerMenu());
-    return { isOpen, handleOpen };
+export default function useBurgerMenu() {
+  const isOpen = useSelector(getHamburgerMenuActive);
+  const dispatch = useDispatch();
+  const handleOpen = useCallback(() => dispatch(toggleHamburgerMenu()), [dispatch]);
+  const setOpen = useCallback(
+    (value) => dispatch(setHamburgerMenuActive(value)),
+    [dispatch]
+  );
+  return { isOpen, handleOpen, setOpen };
 }

--- a/src/components/dashboard/hooks/useMediaQuery.js
+++ b/src/components/dashboard/hooks/useMediaQuery.js
@@ -1,0 +1,31 @@
+import { useSyncExternalStore } from 'react';
+
+/**
+ * Suscribe a una media query de forma segura para SSR usando
+ * `useSyncExternalStore`: el snapshot del servidor devuelve `false`, así que el
+ * primer render del cliente coincide con el del servidor y no hay parpadeo de
+ * hidratación (regla `rendering-hydration-no-flicker`).
+ *
+ * @param {string} query - media query CSS, p.ej. '(max-width: 1023px)'.
+ * @returns {boolean} si la media query coincide actualmente.
+ */
+export default function useMediaQuery(query) {
+  const subscribe = (onStoreChange) => {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return () => {};
+    }
+    const mql = window.matchMedia(query);
+    mql.addEventListener('change', onStoreChange);
+    return () => mql.removeEventListener('change', onStoreChange);
+  };
+
+  const getSnapshot = () => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false;
+    return window.matchMedia(query).matches;
+  };
+
+  // En el servidor no hay viewport: se asume "escritorio" (no coincide).
+  const getServerSnapshot = () => false;
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/components/icons/close.js
+++ b/src/components/icons/close.js
@@ -1,0 +1,27 @@
+/**
+ * Glifo de cierre (X) para acciones de "cerrar" en popovers y diálogos.
+ * Hereda el color vía `currentColor` y es decorativo (el botón aporta el
+ * nombre accesible mediante `aria-label`).
+ */
+const CloseIcon = ({ className }) => {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M6 6L18 18M18 6L6 18"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+};
+
+export default CloseIcon;

--- a/src/components/selection/selection.js
+++ b/src/components/selection/selection.js
@@ -34,25 +34,25 @@ const SelectionPanel = () => {
       <Card.Title className="text-white items-end text-sm mt-2">
         Nodos
       </Card.Title>
-      <div className="flex justify-evenly md:flex-row sm:flex-col ">
-        <div className="md:flex-row sm:flex-col">
+      <div className="flex flex-col gap-2 lg:flex-row lg:justify-evenly">
+        <div className="w-full lg:w-auto">
           <label className="label text-white text-sm" htmlFor="sel-node-radius">Radio</label>
           <input
             id="sel-node-radius"
             type="number"
-            className="input w-40 h-6 min-h-6 rounded-md mr-2 bg-parchment text-ink font-mono"
+            className="input w-full lg:w-40 h-6 min-h-6 rounded-md bg-parchment text-ink font-mono"
             placeholder="10"
             min={0}
             defaultValue={globalStyles.nodeStyle.radius}
             onChange={modifyNodeRadius}
           />
         </div>
-        <div className="md:flex-row sm:flex-col">
+        <div className="w-full lg:w-auto">
           <label className="label text-white text-sm" htmlFor="sel-node-color">Color</label>
           <ColorField
             id="sel-node-color"
             label="Color de nodo"
-            swatchClassName="w-40 h-6 min-h-6 rounded-md"
+            className="block w-full lg:w-40" swatchClassName="w-full lg:w-40 h-6 min-h-6 rounded-md"
             defaultValue={globalStyles.nodeStyle.fill}
             onChange={modifyNodeColor}
           />
@@ -62,25 +62,25 @@ const SelectionPanel = () => {
       <Card.Title className="text-white items-end text-sm mt-2">
         Etiquetas
       </Card.Title>
-      <div className="flex justify-evenly md:flex-row sm:flex-col ">
-        <div className="md:flex-row sm:flex-col">
+      <div className="flex flex-col gap-2 lg:flex-row lg:justify-evenly">
+        <div className="w-full lg:w-auto">
           <label className="label text-white text-sm" htmlFor="sel-label-size">Tamaño</label>
           <input
             id="sel-label-size"
             type="number"
-            className="input w-40 h-6 min-h-6 rounded-md mr-2 bg-parchment text-ink font-mono"
+            className="input w-full lg:w-40 h-6 min-h-6 rounded-md bg-parchment text-ink font-mono"
             placeholder="12"
             min={0}
             defaultValue={globalStyles.labelStyle.fontSize}
             onChange={modifyLabelSize}
           />
         </div>
-        <div className="md:flex-row sm:flex-col">
+        <div className="w-full lg:w-auto">
           <label className="label text-white text-sm" htmlFor="sel-label-color">Color</label>
           <ColorField
             id="sel-label-color"
             label="Color de etiqueta"
-            swatchClassName="w-40 h-6 min-h-6 rounded-md"
+            className="block w-full lg:w-40" swatchClassName="w-full lg:w-40 h-6 min-h-6 rounded-md"
             defaultValue={globalStyles.labelStyle.fill}
             onChange={modifyLabelColor}
           />
@@ -90,25 +90,25 @@ const SelectionPanel = () => {
       <Card.Title className="text-white items-end text-sm mt-2">
         Enlaces
       </Card.Title>
-      <div className="flex justify-evenly md:flex-row sm:flex-col ">
-        <div className="md:flex-row sm:flex-col relative">
+      <div className="flex flex-col gap-2 lg:flex-row lg:justify-evenly">
+        <div className="w-full lg:w-auto relative">
           <label className="label text-white text-sm" htmlFor="sel-path-width">Ancho</label>
           <input
             id="sel-path-width"
             type="number"
-            className="input w-40 h-6 min-h-6 rounded-md mr-2 bg-parchment text-ink font-mono"
+            className="input w-full lg:w-40 h-6 min-h-6 rounded-md bg-parchment text-ink font-mono"
             placeholder="2"
             min={0}
             defaultValue={globalStyles.pathStyle.strokeWidth}
             onChange={modifyPathWidth}
           />
         </div>
-        <div className="md:flex-row sm:flex-col">
+        <div className="w-full lg:w-auto">
           <label className="label text-white text-sm" htmlFor="sel-path-color">Color</label>
           <ColorField
             id="sel-path-color"
             label="Color de enlace"
-            swatchClassName="w-40 h-6 min-h-6 rounded-md"
+            className="block w-full lg:w-40" swatchClassName="w-full lg:w-40 h-6 min-h-6 rounded-md"
             defaultValue={globalStyles.pathStyle.stroke}
             onChange={modifyPathColor}
           />

--- a/src/components/submenu/submenu.js
+++ b/src/components/submenu/submenu.js
@@ -1,14 +1,63 @@
-import React, { useEffect, useRef } from 'react';
-import useSubMenu from './useSubmenu';
+import { useEffect, useRef } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import useSubMenu from './useSubmenu';
 import { getTree } from '../store/tree/slice';
 import { addIds } from '../store/selection/slice';
 import { collectSubtreeIds } from '@/lib/TreeData';
 import ColorField from '../common/colorField';
+import CloseIcon from '../icons/close';
+import BranchGlyph from '../icons/branchGlyph';
+
+// Título y microcopy por tipo de elemento. Centralizar el texto mantiene el
+// menú consistente y fácil de traducir/ajustar en un solo lugar.
+const TYPE_META = {
+  node: { title: 'Editar nodo', hint: 'Ajusta el tamaño y el color del nodo.' },
+  label: { title: 'Editar etiqueta', hint: 'Cambia el tamaño y el color del texto.' },
+  link: { title: 'Editar enlace', hint: 'Define el grosor y el color de la rama.' },
+};
+
+// JSX estático hoisteado fuera del componente (rendering-hoist-jsx): un glifo
+// distinto por tipo para que el encabezado sea reconocible de un vistazo.
+const TYPE_ICON = {
+  node: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle
+        cx="12"
+        cy="12"
+        r="5.5"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        fill="currentColor"
+        fillOpacity="0.18"
+      />
+    </svg>
+  ),
+  label: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M6 8h12M6 12h8M6 16h6"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+    </svg>
+  ),
+  link: (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path
+        d="M6 5v14M6 9h6M6 15h9"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        fill="none"
+      />
+    </svg>
+  ),
+};
 
 const SubMenu = () => {
   const {
-    contextMenu,    
+    contextMenu,
     modifyNodeRadius,
     modifyNodeColor,
     modifyLabelSize,
@@ -23,19 +72,39 @@ const SubMenu = () => {
   const componentId = component.data?.id;
   const menuRef = useRef(null);
 
-  // Move focus into the editor when it opens so keyboard users land on it, and
-  // let Escape close it. `toggled` is true while hidden (WCAG 2.1.2).
+  // Guarda el handler en una ref (advanced-event-handler-refs) para que los
+  // listeners globales no se vuelvan a suscribir en cada render.
+  const handleCloseRef = useRef(handleClose);
+  handleCloseRef.current = handleClose;
+
+  // Al abrir, mueve el foco al editor para que el teclado aterrice en él
+  // (WCAG 2.1.2). `toggled` es true mientras está oculto.
   useEffect(() => {
     if (!toggled) {
       menuRef.current?.focus();
     }
   }, [toggled]);
 
-  const handleKeyDown = (event) => {
-    if (event.key === 'Escape') {
-      handleClose();
-    }
-  };
+  // Mientras está abierto: Escape cierra y un clic fuera también, ignorando el
+  // popover del selector de color (se renderiza en un portal en <body>).
+  useEffect(() => {
+    if (toggled) return undefined;
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') handleCloseRef.current();
+    };
+    const onPointerDown = (event) => {
+      const target = event.target;
+      if (menuRef.current?.contains(target)) return;
+      if (target.closest?.('[data-color-popover]')) return;
+      handleCloseRef.current();
+    };
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('mousedown', onPointerDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('mousedown', onPointerDown);
+    };
+  }, [toggled]);
 
   const nodeRadius = component.data?.nodeStyle?.radius ?? globalStyles.nodeStyle.radius;
   const nodeFill = component.data?.nodeStyle?.fill ?? globalStyles.nodeStyle.fill;
@@ -43,137 +112,168 @@ const SubMenu = () => {
   const labelFill = component.data?.labelStyle?.fill ?? globalStyles.labelStyle.fill;
   const pathStrokeWidth = component.data?.pathStyle?.strokeWidth ?? globalStyles.pathStyle.strokeWidth;
   const pathStroke = component.data?.pathStyle?.stroke ?? globalStyles.pathStyle.stroke;
-  const getTitle = () => {
-    switch (typeElement) {
-      case 'node':
-        return 'Editar Nodo';
-      case 'label':
-        return 'Editar Etiqueta';
-      case 'link':
-        return 'Editar Enlace';
-      default:
-        return '';
-    }
+
+  const meta = TYPE_META[typeElement] ?? { title: 'Editar elemento', hint: '' };
+
+  // Descripción declarativa de los campos por tipo: una sola fuente de verdad
+  // que el render recorre, en lugar de bloques condicionales repetidos.
+  const fields = {
+    node: [
+      {
+        control: 'number',
+        id: 'submenu-node-radius',
+        key: `node-radius-${componentId}`,
+        label: 'Radio',
+        value: nodeRadius,
+        onChange: modifyNodeRadius,
+      },
+      {
+        control: 'color',
+        id: 'submenu-node-color',
+        key: `node-color-${componentId}`,
+        label: 'Color',
+        srLabel: 'Color de nodo',
+        value: nodeFill,
+        onChange: modifyNodeColor,
+      },
+    ],
+    label: [
+      {
+        control: 'number',
+        id: 'submenu-label-size',
+        key: `label-size-${componentId}`,
+        label: 'Tamaño',
+        value: labelFontSize,
+        onChange: modifyLabelSize,
+      },
+      {
+        control: 'color',
+        id: 'submenu-label-color',
+        key: `label-color-${componentId}`,
+        label: 'Color',
+        srLabel: 'Color de etiqueta',
+        value: labelFill,
+        onChange: modifyLabelColor,
+      },
+    ],
+    link: [
+      {
+        control: 'number',
+        id: 'submenu-path-width',
+        key: `path-width-${componentId}`,
+        label: 'Grosor',
+        value: pathStrokeWidth,
+        onChange: modifyWidthPath,
+      },
+      {
+        control: 'color',
+        id: 'submenu-path-color',
+        key: `path-color-${componentId}`,
+        label: 'Color',
+        srLabel: 'Color de enlace',
+        value: pathStroke,
+        onChange: modifyColorPath,
+      },
+    ],
+  };
+  const activeFields = fields[typeElement] ?? [];
+
+  const handleSelectSubtree = () => {
+    if (!component.data) return;
+    const ids = collectSubtreeIds(component.data);
+    dispatch(addIds(ids));
+    handleClose();
   };
 
   return (
     <div
       id="contextMenuObject"
       ref={menuRef}
-      role="menu"
-      aria-label={getTitle() || 'Editar elemento'}
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="contextMenuTitle"
       tabIndex={-1}
-      onKeyDown={handleKeyDown}
-      className="absolute bg-white shadow-lg z-50 rounded-md p-4 focus:outline-none"
+      className="context-menu-pop absolute z-50 w-64 overflow-hidden rounded-xl border border-ink/10 bg-white shadow-xl focus:outline-none"
       style={{
         left: `${pointerX}px`,
         top: `${pointerY}px`,
       }}
       hidden={toggled}
     >
-      <ul className="list-none m-0 p-0 space-y-4">
-        <li className="text-lg font-semibold text-gray-700">{getTitle()}</li>
-        {typeElement === 'node' && (
-          <>
-            <li className="flex items-center space-x-2">
-              <label className="text-black text-sm" htmlFor="submenu-node-radius">Radio</label>
-              <input
-                id="submenu-node-radius"
-                key={`node-radius-${componentId}`}
-                type="number"
-                className="w-40 h-8 rounded-md bg-parchment text-ink font-mono p-1 ml-auto"
-                placeholder="10px"
-                min={0}
-                defaultValue={nodeRadius}
-                onChange={modifyNodeRadius}
-              />
-            </li>
-            <li className="flex items-center space-x-2">
-              <label className="text-black text-sm" htmlFor="submenu-node-color">Color</label>
-              <ColorField
-                id="submenu-node-color"
-                key={`node-color-${componentId}`}
-                label="Color de nodo"
-                className="ml-auto"
-                swatchClassName="w-40 h-8 rounded-md"
-                defaultValue={nodeFill}
-                onChange={modifyNodeColor}
-              />
-            </li>
-          </>
-        )}
-        {typeElement === 'label' && (
-          <>
-            <li className="flex items-center space-x-2">
-              <label className="text-black text-sm" htmlFor="submenu-label-size">Tamaño</label>
-              <input
-                id="submenu-label-size"
-                key={`label-size-${componentId}`}
-                type="number"
-                className="w-40 h-8 rounded-md bg-parchment text-ink font-mono p-1 ml-auto"
-                placeholder="10px"
-                min={0}
-                defaultValue={labelFontSize}
-                onChange={modifyLabelSize}
-              />
-            </li>
-            <li className="flex items-center">
-              <label className="text-black text-sm" htmlFor="submenu-label-color">Color</label>
-              <ColorField
-                id="submenu-label-color"
-                key={`label-color-${componentId}`}
-                label="Color de etiqueta"
-                className="ml-auto"
-                swatchClassName="w-40 h-8 rounded-md"
-                defaultValue={labelFill}
-                onChange={modifyLabelColor}
-              />
-            </li>
-          </>
-        )}
-        {typeElement === 'link' && (
-          <>
-            <li className="flex items-center space-x-2">
-              <label className="text-black text-sm" htmlFor="submenu-path-width">Tamaño</label>
-              <input
-                id="submenu-path-width"
-                key={`path-width-${componentId}`}
-                type="number"
-                className="w-40 h-8 rounded-md bg-parchment text-ink font-mono p-1 ml-auto"
-                placeholder="10px"
-                min={0}
-                defaultValue={pathStrokeWidth}
-                onChange={modifyWidthPath}
-              />
-            </li>
-            <li className="flex items-center space-x-2">
-              <label className="text-black text-sm" htmlFor="submenu-path-color">Color</label>
-              <ColorField
-                id="submenu-path-color"
-                key={`path-color-${componentId}`}
-                label="Color de enlace"
-                className="ml-auto"
-                swatchClassName="w-40 h-8 rounded-md"
-                defaultValue={pathStroke}
-                onChange={modifyColorPath}
-              />
-            </li>
-          </>
-        )}
-        <li>
-          <button
-            className="btn btn-sm btn-primary text-white w-full mt-2"
-            onClick={() => {
-              if (!component.data) return;
-              const ids = collectSubtreeIds(component.data);
-              dispatch(addIds(ids));
-              handleClose();
-            }}
+      <header className="flex items-start gap-3 border-b border-ink/10 px-4 py-3">
+        <span
+          className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-herbarium/10 text-herbarium"
+          aria-hidden="true"
+        >
+          {TYPE_ICON[typeElement] ?? null}
+        </span>
+        <div className="min-w-0">
+          <h2
+            id="contextMenuTitle"
+            className="font-display text-base font-semibold leading-tight text-ink"
           >
+            {meta.title}
+          </h2>
+          {meta.hint ? <p className="mt-0.5 text-xs text-ink/60">{meta.hint}</p> : null}
+        </div>
+        <button
+          type="button"
+          aria-label="Cerrar"
+          onClick={handleClose}
+          className="ml-auto flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-ink/50 transition-colors hover:bg-ink/5 hover:text-ink"
+        >
+          <CloseIcon className="h-4 w-4" />
+        </button>
+      </header>
+
+      <div className="px-4 pb-4 pt-3">
+        <div className="space-y-3">
+          {activeFields.map((field) =>
+            field.control === 'number' ? (
+              <div key={field.key} className="flex items-center justify-between gap-3">
+                <label className="text-sm text-ink/80" htmlFor={field.id}>
+                  {field.label}
+                </label>
+                <input
+                  id={field.id}
+                  key={field.key}
+                  type="number"
+                  className="h-9 w-28 rounded-lg border border-ink/15 bg-parchment px-2 font-mono text-sm text-ink focus:border-signal focus:outline-none"
+                  placeholder="10"
+                  min={0}
+                  defaultValue={field.value}
+                  onChange={field.onChange}
+                />
+              </div>
+            ) : (
+              <div key={field.key} className="flex items-center justify-between gap-3">
+                <label className="text-sm text-ink/80" htmlFor={field.id}>
+                  {field.label}
+                </label>
+                <ColorField
+                  id={field.id}
+                  key={field.key}
+                  label={field.srLabel}
+                  defaultValue={field.value}
+                  swatchClassName="h-9 w-28 rounded-lg"
+                  onChange={field.onChange}
+                />
+              </div>
+            )
+          )}
+        </div>
+
+        <div className="mt-4 border-t border-ink/10 pt-3">
+          <button
+            type="button"
+            className="btn btn-sm btn-primary w-full gap-2 text-white"
+            onClick={handleSelectSubtree}
+          >
+            <BranchGlyph className="h-4 w-4" />
             Seleccionar subárbol
           </button>
-        </li>
-      </ul>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/submenu/useSubmenu.js
+++ b/src/components/submenu/useSubmenu.js
@@ -18,32 +18,41 @@ const useSubMenu = () => {
 
   const handleContextMenu = (event, component, index, typeElement) => {
     event.preventDefault();
-    const element = document.getElementById(`${typeElement}-${index}`);
     const contextMenu = document.getElementById('contextMenuObject');
     const canvas = document.getElementById('canvas');
-    const sizeCanvas = canvas.getBoundingClientRect();
-    const elementSize = element.getBoundingClientRect();
-    const contextMenuSize = contextMenu.getBoundingClientRect();
-    // se deja un offsetRelativo al tamaño creado
-    const realXMouse = event.pageX;
-    const realYmouse = event.pageY;
-    const offsetX = contextMenuSize.width ? contextMenuSize.width - 5 : 145;
-    const offsetY = contextMenuSize.height ? contextMenuSize.height - 5 : 100;
-    const isRight = elementSize.left - sizeCanvas.x > sizeCanvas.width / 2;
-    const isBottom = elementSize.y + sizeCanvas.y > sizeCanvas.height / 2;
-    
-    // posiciones a guardar para el menu de contexto
-    let newPositionX = isRight
-      ? realXMouse - sizeCanvas.x - offsetX
-      : realXMouse - sizeCanvas.x;
-    let newPositionY = isBottom
-      ? realYmouse + sizeCanvas.y - offsetY
-      : realYmouse + sizeCanvas.y;
-    
-      
+    if (!canvas) return;
+
+    // El menú está posicionado de forma absoluta dentro de `#canvas`
+    // (su offset parent), así que trabajamos en coordenadas relativas al canvas
+    // usando `clientX/clientY`, que comparten sistema con getBoundingClientRect.
+    const canvasRect = canvas.getBoundingClientRect();
+    const menuRect = contextMenu?.getBoundingClientRect();
+
+    const MARGIN = 8;
+    // Mientras el menú está oculto (display:none) su rect es 0; usamos tamaños
+    // estimados (el ancho es fijo, `w-64`) hasta que se mide tras la 1ª apertura.
+    const menuWidth = menuRect?.width || 256;
+    const menuHeight = menuRect?.height || 280;
+
+    // Posición del cursor relativa al canvas.
+    const cursorX = event.clientX - canvasRect.left;
+    const cursorY = event.clientY - canvasRect.top;
+
+    // Si no cabe a la derecha/abajo del cursor, se abre hacia el lado opuesto
+    // para no taparlo; luego se acota para no salir nunca del canvas.
+    let newPositionX =
+      cursorX + menuWidth + MARGIN > canvasRect.width ? cursorX - menuWidth : cursorX;
+    let newPositionY =
+      cursorY + menuHeight + MARGIN > canvasRect.height ? cursorY - menuHeight : cursorY;
+
+    const maxX = canvasRect.width - menuWidth - MARGIN;
+    const maxY = canvasRect.height - menuHeight - MARGIN;
+    newPositionX = Math.max(MARGIN, Math.min(newPositionX, maxX));
+    newPositionY = Math.max(MARGIN, Math.min(newPositionY, maxY));
+
     // se obtiene el componente correcto dependiendo del tipo de elemento
     const newComponent = typeElement === 'link' ? component.source : component;
-    
+
     dispatch(
       setContextMenu({
         pointerX: newPositionX,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -53,3 +53,24 @@ input[type='number'] {
     opacity: 1;
   }
 }
+
+/* Aparición suave del menú de contexto: una microanimación de escala/opacidad
+   que se reproduce cada vez que el menú pasa de oculto a visible. Respeta la
+   preferencia de movimiento reducido (WCAG 2.3.3). */
+@media (prefers-reduced-motion: no-preference) {
+  .context-menu-pop {
+    transform-origin: top left;
+    animation: phily-context-pop 0.14s ease-out;
+  }
+}
+
+@keyframes phily-context-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}


### PR DESCRIPTION
## Por qué

El menú de contexto que aparece al hacer clic derecho sobre nodos, etiquetas y enlaces del dendrograma era funcional pero poco amigable: una lista plana sin jerarquía visual, sin pistas de qué se está editando y con estilos que no seguían la identidad visual de la app. Este cambio lo rediseña para que sea más claro, consistente y agradable de usar.

## Qué cambia

- **Encabezado contextual**: glifo distinto por tipo (nodo / etiqueta / enlace), título y un microcopy que explica qué se puede ajustar, más un botón de cerrar (✕).
- **Campos más legibles**: etiquetas alineadas, inputs y swatches con el estilo del tema (`ink` / `parchment` / `herbarium` / `signal`), bordes, sombra y esquinas redondeadas.
- **Acción diferenciada**: "Seleccionar subárbol" queda separada del resto con su propio icono.
- **Interacción**: cierre por `Escape` y por clic fuera (ignorando el popover del color picker), con una animación de entrada que respeta `prefers-reduced-motion`.

## Notas para revisión

- Se aplican buenas prácticas de Next/React: semántica correcta (`role="dialog"` en vez de `role="menu"`), JSX estático hoisteado, configuración de campos declarativa en una sola fuente de verdad, y el handler de cierre en una `ref` para no re-suscribir listeners globales en cada render.
- Se conserva el `id="contextMenuObject"` (lo usa el hook de posicionamiento) y todos los handlers existentes del `useSubmenu`, por lo que el comportamiento de edición no cambia.
- El clic-fuera detecta el popover del color picker mediante un nuevo atributo `data-color-popover` en `colorField`, para no cerrar el menú al elegir un color.

Lint y build pasan localmente.